### PR TITLE
#9 feat(theme): 오늘의 주제 API 구현

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -32,6 +32,8 @@ message = "변경사항의 범위를 입력하세요 (예: auth, user):"
 choices = [
     { value = "config", name = "config: 환경 구성" },
     { value = "api", name = "api: api 문서" },
+    { value = "theme", name = "theme: Theme(주제) API" },
+    { value = "diary", name = "diary: Diary(일기) API" },
     { value = "wiki", name = "wiki: wiki 문서" }
 ]
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,26 @@
+import { pathsToModuleNameMapper, JestConfigWithTsJest } from 'ts-jest';
+import { compilerOptions } from './tsconfig.json';
+import * as path from 'path';
+
+const rootDir = path.resolve();
+
+const config: JestConfigWithTsJest = {
+  moduleFileExtensions: [
+    'js',
+    'json',
+    'ts',
+  ],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: `${rootDir}/`,
+  }),
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.config.ts",
     "prepare": "husky"
   },
   "dependencies": {
@@ -24,9 +24,13 @@
     "@nestjs/config": "^4.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^5.0.1",
     "@nestjs/swagger": "^11.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cron": "3.5.0",
+    "dayjs": "^1.11.13",
+    "jest-mock-extended": "4.0.0-beta1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -55,22 +59,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.0.11(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.11)
+      '@nestjs/schedule':
+        specifier: ^5.0.1
+        version: 5.0.1(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.11)
       '@nestjs/swagger':
         specifier: ^11.1.0
         version: 11.1.0(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.11)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
@@ -29,6 +32,15 @@ importers:
       class-validator:
         specifier: ^0.14.1
         version: 0.14.1
+      cron:
+        specifier: 3.5.0
+        version: 3.5.0
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
+      jest-mock-extended:
+        specifier: 4.0.0-beta1
+        version: 4.0.0-beta1(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.11)(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -778,6 +790,12 @@ packages:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
 
+  '@nestjs/schedule@5.0.1':
+    resolution: {integrity: sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.0.2':
     resolution: {integrity: sha512-C4KM3BHBG6tRX8t5UrHdUq8Y49asEfJUora/fBXge3UTAnxKGlXc20p5s2Q0Q1+l+1YaXqTrKGSIbYXdPX8r9g==}
     peerDependencies:
@@ -1019,6 +1037,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/luxon@3.4.2':
+    resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -1597,9 +1618,15 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
+  cron@3.5.0:
+    resolution: {integrity: sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
@@ -2304,6 +2331,13 @@ packages:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-mock-extended@4.0.0-beta1:
+    resolution: {integrity: sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==}
+    peerDependencies:
+      '@jest/globals': ^28.0.0 || ^29.0.0
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2473,6 +2507,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@3.5.0:
+    resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -3165,6 +3203,14 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-essentials@10.0.4:
+    resolution: {integrity: sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ts-jest@29.2.6:
     resolution: {integrity: sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==}
@@ -4211,6 +4257,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@5.0.1(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.11)':
+    dependencies:
+      '@nestjs/common': 11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.0.11(@nestjs/common@11.0.11(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.0.11)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 3.5.0
+
   '@nestjs/schematics@11.0.2(chokidar@4.0.3)(typescript@5.7.3)':
     dependencies:
       '@angular-devkit/core': 19.2.0(chokidar@4.0.3)
@@ -4463,6 +4515,8 @@ snapshots:
       pretty-format: 29.7.0
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/luxon@3.4.2': {}
 
   '@types/methods@1.1.4': {}
 
@@ -5150,11 +5204,18 @@ snapshots:
 
   create-require@1.1.1: {}
 
+  cron@3.5.0:
+    dependencies:
+      '@types/luxon': 3.4.2
+      luxon: 3.5.0
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  dayjs@1.11.13: {}
 
   debug@4.3.6:
     dependencies:
@@ -5967,6 +6028,13 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock-extended@4.0.0-beta1(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.11)(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
+    dependencies:
+      '@jest/globals': 29.7.0
+      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.11)(@types/node@22.13.10)(typescript@5.8.2))
+      ts-essentials: 10.0.4(typescript@5.8.2)
+      typescript: 5.8.2
+
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -6210,6 +6278,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@3.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -6866,6 +6936,10 @@ snapshots:
 
   ts-api-utils@2.0.1(typescript@5.8.2):
     dependencies:
+      typescript: 5.8.2
+
+  ts-essentials@10.0.4(typescript@5.8.2):
+    optionalDependencies:
       typescript: 5.8.2
 
   ts-jest@29.2.6(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.11)(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 
 import { validate } from '@common/env';
+import { ThemeModule } from '@theme/theme.module';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -12,6 +14,8 @@ import { AppService } from './app.service';
       isGlobal: true,
       validate,
     }),
+    ScheduleModule.forRoot(),
+    ThemeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/env/env.ts
+++ b/src/common/env/env.ts
@@ -5,7 +5,7 @@ import {
   Max, Min,
 } from 'class-validator';
 
-enum Environment {
+export enum Environment {
   Development = 'development',
   Production = 'production',
   Test = 'test',

--- a/src/common/env/index.ts
+++ b/src/common/env/index.ts
@@ -1,2 +1,2 @@
-export { EnvironmentVariables } from './env';
+export { Environment, EnvironmentVariables } from './env';
 export { validate } from '@common/env/validate';

--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('Asia/Seoul');
+
+export function hasTimePassed(target: Date, unit: dayjs.UnitType, threshold: number): boolean {
+  return dayjs().diff(dayjs(target), unit) >= threshold;
+}

--- a/src/modules/theme/entities/theme-log.entity.ts
+++ b/src/modules/theme/entities/theme-log.entity.ts
@@ -1,0 +1,5 @@
+export class ThemeLogEntity {
+  id: string;
+  theme_id: string;
+  created_at: Date;
+}

--- a/src/modules/theme/entities/theme.entity.ts
+++ b/src/modules/theme/entities/theme.entity.ts
@@ -1,0 +1,4 @@
+export class ThemeEntity {
+  id: string;
+  text: string;
+}

--- a/src/modules/theme/interface/index.ts
+++ b/src/modules/theme/interface/index.ts
@@ -1,0 +1,1 @@
+export { ThemeRepositoryBase } from './theme.repository.interface';

--- a/src/modules/theme/interface/theme.repository.interface.ts
+++ b/src/modules/theme/interface/theme.repository.interface.ts
@@ -1,0 +1,9 @@
+import { ThemeEntity } from '@theme/entities/theme.entity';
+import { ThemeLogEntity } from '@theme/entities/theme-log.entity';
+
+export interface ThemeRepositoryBase {
+  findById(id: string): Promise<ThemeEntity | null>;
+  getRandomTheme(): Promise<ThemeEntity>;
+  getLastLog(): Promise<ThemeLogEntity | null>;
+  saveLog(themeEntity: ThemeEntity): Promise<void>;
+}

--- a/src/modules/theme/responses/index.ts
+++ b/src/modules/theme/responses/index.ts
@@ -1,0 +1,1 @@
+export { TodayThemeResponse } from './todayTheme.response';

--- a/src/modules/theme/responses/todayTheme.response.ts
+++ b/src/modules/theme/responses/todayTheme.response.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TodayThemeResponse {
+  @ApiProperty({ description: '오늘의 주제', example: '오늘 한 일에서 앞으로도 계속 하고 싶은 일이 있나요?' })
+  theme: string;
+}

--- a/src/modules/theme/swagger/index.ts
+++ b/src/modules/theme/swagger/index.ts
@@ -1,0 +1,1 @@
+export { ApiTodayResponses } from './today.swagger';

--- a/src/modules/theme/swagger/today.swagger.ts
+++ b/src/modules/theme/swagger/today.swagger.ts
@@ -1,0 +1,10 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, getSchemaPath } from '@nestjs/swagger';
+import { TodayThemeResponse } from '@theme/responses';
+
+export function ApiTodayResponses() {
+  return applyDecorators(
+    ApiOperation({ description: '오늘의 주제를 반환합니다.' }),
+    ApiOkResponse({ description: '요청이 성공했을 경우', schema: { allOf: [{ $ref: getSchemaPath(TodayThemeResponse) }] } })
+  );
+}

--- a/src/modules/theme/theme.controller.spec.ts
+++ b/src/modules/theme/theme.controller.spec.ts
@@ -1,0 +1,44 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ThemeController } from '@theme/theme.controller';
+import { ThemeService } from '@theme/theme.service';
+import { TodayThemeResponse } from '@theme/responses';
+
+describe('ThemeController', () => {
+  let controller: ThemeController;
+  let service: MockProxy<ThemeService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ThemeController],
+      providers: [ThemeService],
+    })
+      .overrideProvider(ThemeService)
+      .useValue(mock<ThemeService>())
+      .compile();
+
+    controller = module.get<ThemeController>(ThemeController);
+    service = module.get<MockProxy<ThemeService>>(ThemeService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('today', () => {
+    const theme = '오늘의 주제';
+
+    it('서비스에서 받은 오늘의 주제를 응답의 형식에 맞게 반환한다.', () => {
+      const expected: TodayThemeResponse = {
+        theme,
+      };
+      const getTodayThemeMock = service.getTodayTheme.mockReturnValue(theme);
+
+      const actual = controller.today();
+
+      expect(getTodayThemeMock).toHaveBeenCalled();
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/modules/theme/theme.controller.ts
+++ b/src/modules/theme/theme.controller.ts
@@ -1,0 +1,30 @@
+import {
+  Controller,
+  Get,
+  HttpCode, HttpStatus,
+} from '@nestjs/common';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
+
+import { ThemeService } from '@theme/theme.service';
+import { TodayThemeResponse } from '@theme/responses';
+import { ApiTodayResponses } from '@theme/swagger';
+
+@ApiTags('Theme')
+@ApiExtraModels(TodayThemeResponse)
+@Controller('theme')
+export class ThemeController {
+  constructor(
+    private readonly themeService: ThemeService,
+  ) {}
+
+  @Get('today')
+  @HttpCode(HttpStatus.OK)
+  @ApiTodayResponses()
+  today(): TodayThemeResponse {
+    const theme = this.themeService.getTodayTheme();
+
+    return {
+      theme,
+    };
+  }
+}

--- a/src/modules/theme/theme.module.ts
+++ b/src/modules/theme/theme.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+
+import { ThemeController } from '@theme/theme.controller';
+import { ThemeService } from '@theme/theme.service';
+import { ThemeScheduler } from '@theme/theme.scheduler';
+import { ThemeRepository } from '@theme/theme.repository';
+
+@Module({
+  controllers: [ThemeController],
+  providers: [
+    ThemeService,
+    ThemeRepository,
+    ThemeScheduler,
+  ],
+})
+export class ThemeModule {}

--- a/src/modules/theme/theme.repository.ts
+++ b/src/modules/theme/theme.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+
+import { ThemeRepositoryBase } from '@theme/interface';
+import { ThemeEntity } from '@theme/entities/theme.entity';
+import { ThemeLogEntity } from '@theme/entities/theme-log.entity';
+
+@Injectable()
+export class ThemeRepository implements ThemeRepositoryBase {
+  private themes: ThemeEntity[] = [
+    { id: '1', text: '오늘 한 일 중 앞으로도 계속하고 싶은 일이 있나요?' },
+    { id: '2', text: '오늘 나를 웃게 만든 일은 무엇이었나요?' },
+    { id: '3', text: '오늘 나를 가장 힘들게 한 순간은 언제였나요?' },
+    { id: '4', text: '오늘 하루를 되돌아보면 어떤 감정이 가장 컸나요?' },
+    { id: '5', text: '오늘 내가 누군가에게 친절을 베푼 순간이 있었나요?' },
+    { id: '6', text: '오늘 내가 배운 것이 있다면 무엇인가요?' },
+    { id: '7', text: '오늘 하루를 동물이나 날씨로 표현한다면 무엇일까요? 왜 그렇게 느꼈나요?' },
+    { id: '8', text: '오늘 내가 집중했던 일은 무엇이었고, 만족스러웠나요?' },
+    { id: '9', text: '오늘 내가 무심코 지나친 작은 행복이 있다면 무엇이었나요?' },
+    { id: '10', text: '오늘 하루를 다시 산다면 무엇을 바꾸고 싶나요?' },
+  ];
+  private themeLogs: ThemeLogEntity[] = [];
+  private logId = '0';
+
+  constructor() {}
+
+  findById(id: string): Promise<ThemeEntity | null> {
+    return Promise.resolve(this.themes.find((v) => v.id === id) || null);
+  }
+
+  getRandomTheme(): Promise<ThemeEntity> {
+    const theme = this.themes[Math.floor(Math.random() * this.themes.length)];
+    return Promise.resolve(theme);
+  }
+
+  getLastLog(): Promise<ThemeLogEntity | null> {
+    return Promise.resolve(this.themeLogs.at(-1) || null);
+  }
+
+  saveLog(themeEntity: ThemeEntity): Promise<void> {
+    if (this.themeLogs.length > 10) this.themeLogs.shift();
+
+    this.logId = String(Number(this.logId) + 1);
+
+    this.themeLogs.push({
+      id: this.logId,
+      theme_id: themeEntity.id,
+      created_at: new Date(),
+    });
+    return Promise.resolve();
+  }
+}

--- a/src/modules/theme/theme.scheduler.ts
+++ b/src/modules/theme/theme.scheduler.ts
@@ -1,0 +1,39 @@
+import { CronJob } from 'cron';
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CronExpression, SchedulerRegistry } from '@nestjs/schedule';
+
+import { ThemeService } from '@theme/theme.service';
+import { Environment, EnvironmentVariables } from '@common/env';
+
+@Injectable()
+export class ThemeScheduler implements OnModuleInit {
+  private readonly logger = new Logger(ThemeScheduler.name);
+
+  constructor(
+    private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly configService: ConfigService<EnvironmentVariables, true>,
+    private readonly themeService: ThemeService,
+  ) {}
+
+  onModuleInit(): void {
+    const environment = this.configService.get<Environment>('NODE_ENV');
+
+    const cronExpression = environment === Environment.Development
+      ? CronExpression.EVERY_MINUTE
+      : CronExpression.EVERY_DAY_AT_4AM;
+
+    const job = new CronJob(cronExpression, () => {
+      void this.themeService.triggerUpdateTodayTheme();
+    });
+
+    this.schedulerRegistry.addCronJob('update-theme', job);
+    job.start();
+    this.logger.debug(`오늘의 주제 스케쥴러 실행 주기 : ${this.cronExpressionToString(cronExpression)}`);
+  }
+
+  private cronExpressionToString(cronExpression: CronExpression) {
+    return Object.entries(CronExpression).find(([, v]) => v === cronExpression)?.[0];
+  }
+}

--- a/src/modules/theme/theme.service.spec.ts
+++ b/src/modules/theme/theme.service.spec.ts
@@ -1,0 +1,133 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ThemeService } from '@theme/theme.service';
+import { ThemeRepository } from '@theme/theme.repository';
+import { Environment } from '@common/env';
+import { ThemeEntity } from '@theme/entities/theme.entity';
+import { ThemeLogEntity } from '@theme/entities/theme-log.entity';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+  let mockConfigService: MockProxy<ConfigService>;
+  let mockRepository: MockProxy<ThemeRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ThemeService,
+        ThemeRepository,
+        ConfigService,
+      ],
+    })
+      .overrideProvider(ThemeRepository)
+      .useValue(mock<ThemeRepository>())
+      .overrideProvider(ConfigService)
+      .useValue(mock<ConfigService>())
+      .compile();
+
+    service = module.get<ThemeService>(ThemeService);
+    mockRepository = module.get(ThemeRepository);
+    mockConfigService = module.get(ConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getTodayTheme', () => {
+    const theme = '오늘의 주제';
+    it('오늘의 주제를 정상적으로 반환한다.', async () => {
+      const expected = theme;
+      mockRepository.getRandomTheme.mockResolvedValue({ id: '1', text: theme });
+      mockConfigService.get.mockReturnValue(Environment.Test);
+      await service.onModuleInit();
+
+      const actual = service.getTodayTheme();
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('updateTodayTheme', () => {
+    const theme = '오늘의 주제';
+    const themeEntity: ThemeEntity = {
+      id: '1',
+      text: theme,
+    };
+    it('오늘의 주제를 업데이트한다.', async () => {
+      const mockGetRandomTheme = mockRepository.getRandomTheme.mockResolvedValue(themeEntity);
+      const mockSaveLog = mockRepository.saveLog.mockResolvedValue();
+
+      await service.updateTodayTheme();
+
+      expect(mockGetRandomTheme).toHaveBeenCalled();
+      expect(mockSaveLog).toHaveBeenCalledWith(themeEntity);
+    });
+  });
+
+  describe('triggerUpdateTodayTheme', () => {
+    const theme = '오늘의 주제';
+    const themeEntity: ThemeEntity = {
+      id: '1',
+      text: theme,
+    };
+
+    it('로그가 존재하지 않을 경우, 오늘의 주제를 새롭게 설정한다.', async () => {
+      const mockGetLastLog = mockRepository.getLastLog.mockResolvedValue(null);
+      const mockGetRandomTheme = mockRepository.getRandomTheme.mockResolvedValue(themeEntity);
+      const mockConfigGet = mockConfigService.get.mockReturnValue(Environment.Test);
+
+      await service.triggerUpdateTodayTheme();
+      const result = service.getTodayTheme();
+
+      expect(mockGetLastLog).toHaveBeenCalled();
+      expect(mockConfigGet).not.toHaveBeenCalled();
+      expect(mockGetRandomTheme).toHaveBeenCalled();
+      expect(result).toEqual(themeEntity.text);
+    });
+
+    it('로그가 존재하며, 오늘이 지났을 경우 오늘의 주제를 새롭게 설정한다.', async () => {
+      const themeLogEntity: ThemeLogEntity = {
+        id: '1',
+        theme_id: '1',
+        created_at: new Date('1990-01-01'),
+      };
+      mockRepository.getLastLog.mockResolvedValue(themeLogEntity);
+      const mockFindById = mockRepository.findById.mockResolvedValue(null);
+      const mockGetRandomTheme = mockRepository.getRandomTheme.mockResolvedValue(themeEntity);
+      const mockSaveLog = mockRepository.saveLog.mockResolvedValue();
+      mockConfigService.get.mockReturnValue(Environment.Test);
+
+      await service.triggerUpdateTodayTheme();
+      const result = service.getTodayTheme();
+
+      expect(mockGetRandomTheme).toHaveBeenCalled();
+      expect(mockSaveLog).toHaveBeenCalledWith(themeEntity);
+      expect(result).toEqual(themeEntity.text);
+      expect(mockFindById).not.toHaveBeenCalled();
+    });
+
+    it('로그가 존재하며, 오늘이 지나지 않았을 경우 오늘의 주제를 로그로부터 가져온다.', async () => {
+      const themeLogEntity: ThemeLogEntity = {
+        id: '1',
+        theme_id: '1',
+        created_at: new Date(),
+      };
+      mockRepository.getLastLog.mockResolvedValue(themeLogEntity);
+      const mockFindById = mockRepository.findById.mockResolvedValue(themeEntity);
+      const mockGetRandomTheme = mockRepository.getRandomTheme.mockResolvedValue({ id: '2', text: '' });
+      const mockSaveLog = mockRepository.saveLog.mockResolvedValue();
+      mockConfigService.get.mockReturnValue(Environment.Test);
+
+      await service.triggerUpdateTodayTheme();
+      const result = service.getTodayTheme();
+
+      expect(mockGetRandomTheme).not.toHaveBeenCalled();
+      expect(mockSaveLog).not.toHaveBeenCalled();
+      expect(result).toEqual(themeEntity.text);
+      expect(mockFindById).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/theme/theme.service.ts
+++ b/src/modules/theme/theme.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+
+import { hasTimePassed } from '@common/utils/date';
+import { ThemeEntity } from '@theme/entities/theme.entity';
+import { ThemeRepository } from '@theme/theme.repository';
+import { ConfigService } from '@nestjs/config';
+import { Environment, EnvironmentVariables } from '@common/env';
+
+
+@Injectable()
+export class ThemeService implements OnModuleInit {
+  private readonly logger = new Logger(ThemeService.name);
+  private todayTheme: ThemeEntity;
+
+  constructor(
+    private readonly themeRepository: ThemeRepository,
+    private readonly configService: ConfigService<EnvironmentVariables, true>
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.triggerUpdateTodayTheme();
+  }
+
+  getTodayTheme(): string {
+    return this.todayTheme.text;
+  }
+
+  async updateTodayTheme(): Promise<void> {
+    this.todayTheme = await this.themeRepository.getRandomTheme();
+    await this.themeRepository.saveLog(this.todayTheme);
+    this.logger.debug(`오늘의 새로운 주제 : ${this.todayTheme.text}`);
+  }
+
+  async triggerUpdateTodayTheme(): Promise<void> {
+    this.logger.debug('새로운 주제 할당 스케쥴러 실행');
+    const lastLog = await this.themeRepository.getLastLog();
+
+    if (!lastLog) {
+      await this.updateTodayTheme();
+      return;
+    }
+
+    const isAfter = () => this.configService.get<Environment>('NODE_ENV') === Environment.Development
+      ? hasTimePassed(lastLog.created_at, 'minute', 1)
+      : hasTimePassed(lastLog.created_at, 'day', 1);
+
+    if (isAfter()) {
+      await this.updateTodayTheme();
+      return;
+    }
+
+    this.logger.debug('마지막 로그로부터 새로운 주제를 할당합니다.');
+    const lastTheme = await this.themeRepository.findById(lastLog.theme_id);
+    if (lastTheme) {
+      this.todayTheme = lastTheme;
+      this.logger.debug(`오늘의 주제 : ${this.todayTheme.text}`);
+    }
+  }
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
@@ -21,5 +21,9 @@ describe('AppController (e2e)', () => {
       .get('/')
       .expect(200)
       .expect('Hello World!');
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 });

--- a/test/jest-e2e.config.ts
+++ b/test/jest-e2e.config.ts
@@ -1,0 +1,26 @@
+import { pathsToModuleNameMapper, JestConfigWithTsJest } from 'ts-jest';
+import { compilerOptions } from '../tsconfig.json';
+import * as path from 'path';
+
+const rootDir = path.resolve();
+
+const config: JestConfigWithTsJest = {
+  moduleFileExtensions: [
+    'js',
+    'json',
+    'ts',
+  ],
+  rootDir: '..',
+  testRegex: '.e2e-spec.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: `${rootDir}/`,
+  }),
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,15 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@common/*": ["./src/common/*"]
+      "@common/*": ["./src/common/*"],
+      "@theme/*": ["./src/modules/theme/*"]
     },
     "incremental": true,
     "skipLibCheck": true,
@@ -20,5 +22,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## 변경 사항 요약 (Summary)

- tsconfig.json에 @theme 추가
- theme repository interface를 정의
- env 관련 변수를 추가로 export
- /themes/today 엔드포인트를 구현
- 스케쥴러를 통해 지정된 시간마다 오늘의 주제를 자동으로 업데이트

## 관련 이슈 (Related Issues)

- Closes #9

## 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.