### PR TITLE
#11 feat(diary): 일기 생성 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { ThemeModule } from '@theme/theme.module';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { MeModule } from './modules/me/me.module';
+import { DiaryModule } from './modules/diary/diary.module';
 
 @Module({
   imports: [
@@ -16,6 +18,8 @@ import { AppService } from './app.service';
     }),
     ScheduleModule.forRoot(),
     ThemeModule,
+    MeModule,
+    DiaryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/swagger/config.ts
+++ b/src/common/swagger/config.ts
@@ -7,4 +7,5 @@ export const swaggerConfig = new DocumentBuilder()
   .addTag('User')
   .addTag('Diary')
   .addTag('Theme')
+  .addTag('Me')
   .build();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule } from '@nestjs/swagger';
 
 import { EnvironmentVariables } from '@common/env';
@@ -22,6 +22,13 @@ async function bootstrap() {
   const port = configService.get<number>('PORT');
 
   app.setGlobalPrefix('api/v1');
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    })
+  );
   await app.listen(port, () => {
     logger.log(`server running on : ${host}:${port}`);
     logger.log(`api documentation : ${host}:${port}/${API_DOC_SLUG}`);

--- a/src/modules/diary/diary.mapper.ts
+++ b/src/modules/diary/diary.mapper.ts
@@ -1,0 +1,15 @@
+import { plainToInstance } from 'class-transformer';
+
+import { DiaryEntity } from '@diary/entities';
+import { CreateDiaryDto } from '@diary/dto/create-diary.dto';
+import { DiaryDto } from '@diary/dto';
+
+export class DiaryMapper {
+  static createDtoToEntity(createDiaryDto: CreateDiaryDto): DiaryEntity {
+    return plainToInstance(DiaryEntity, createDiaryDto, { excludeExtraneousValues: true });
+  }
+
+  static toDto(entity: DiaryEntity): DiaryDto {
+    return plainToInstance(DiaryDto, entity, { excludeExtraneousValues: true });
+  }
+}

--- a/src/modules/diary/diary.module.ts
+++ b/src/modules/diary/diary.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { ThemeModule } from '@theme/theme.module';
+import { DiaryService } from '@diary/diary.service';
+import { DiaryRepository } from '@diary/diary.repository';
+
+@Module({
+  imports: [ThemeModule],
+  providers: [
+    DiaryService,
+    DiaryRepository,
+  ],
+  exports: [DiaryService],
+})
+export class DiaryModule {}

--- a/src/modules/diary/diary.repository.ts
+++ b/src/modules/diary/diary.repository.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+
+import { DiaryRepositoryBase } from '@diary/interfaces/diary.repository.interface';
+import { DiaryEntity } from '@diary/entities';
+
+@Injectable()
+export class DiaryRepository implements DiaryRepositoryBase {
+  private diaries: DiaryEntity[] = [];
+  private diaryId = 0;
+  constructor() {}
+
+  async save(diaryEntity: DiaryEntity): Promise<DiaryEntity> {
+    this.diaryId++;
+    this.diaries.push({
+      id: String(this.diaryId),
+      theme_id: diaryEntity.theme_id,
+      title: diaryEntity.title,
+      content: diaryEntity.content,
+      created_at: new Date(),
+    });
+
+    const createdEntity = this.diaries.at(-1);
+
+    if (!createdEntity)
+      return Promise.reject(new Error('Database Error'));
+    else
+      return Promise.resolve(createdEntity);
+  }
+}

--- a/src/modules/diary/diary.service.spec.ts
+++ b/src/modules/diary/diary.service.spec.ts
@@ -1,0 +1,122 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ThemeService } from '@theme/theme.service';
+import { ThemeEntity } from '@theme/entities/theme.entity';
+import { DiaryService } from '@diary/diary.service';
+import { DiaryRepository } from '@diary/diary.repository';
+import { DiaryEntity } from '@diary/entities';
+import { CreateDiaryDto, DiaryDto } from '@diary/dto';
+
+describe('DiaryService', () => {
+  let service: DiaryService;
+  let mockRepository: MockProxy<DiaryRepository>;
+  let mockThemeService: MockProxy<ThemeService>;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DiaryService,
+        DiaryRepository,
+        ThemeService,
+      ],
+    })
+      .overrideProvider(DiaryRepository)
+      .useValue(mock<DiaryRepository>())
+      .overrideProvider(ThemeService)
+      .useValue(mock<ThemeService>())
+      .compile();
+
+    service = module.get<DiaryService>(DiaryService);
+    mockRepository = module.get(DiaryRepository);
+    mockThemeService = module.get(ThemeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createDiary', () => {
+    let themeEntity: ThemeEntity;
+    let getTodayThemeMock: () => ThemeEntity;
+
+    beforeEach(() => {
+      themeEntity = { id: '4', text: '오늘의 주제' };
+      getTodayThemeMock = mockThemeService.getTodayTheme.mockReturnValue(themeEntity);
+    });
+
+    it('use_theme이 true일 경우 theme_id와 함께 저장된다.', async () => {
+      const dto: CreateDiaryDto = {
+        use_theme: true,
+        title: '테스트 제목',
+        content: '테스트 내용',
+      };
+      const toSaveEntity: DiaryEntity = new DiaryEntity({
+        theme_id: themeEntity.id,
+        title: dto.title,
+        content: dto.content,
+      });
+      const saveReturnEntity: DiaryEntity = {
+        id: '1',
+        theme_id: '4',
+        title: '테스트 제목',
+        content: '테스트 내용',
+        created_at: new Date(),
+      };
+
+      const expected: DiaryDto = {
+        id: saveReturnEntity.id,
+        title: saveReturnEntity.title,
+        content: saveReturnEntity.content,
+        created_at: saveReturnEntity.created_at,
+      };
+      const saveMock = mockRepository.save.mockResolvedValue(saveReturnEntity);
+
+      const actual = await service.create(dto);
+
+      expect(actual).toEqual(expected);
+      expect(getTodayThemeMock).toHaveBeenCalledTimes(1);
+      expect(saveMock).toHaveBeenCalledWith(toSaveEntity);
+      expect(saveMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('use_theme이 false일 경우 theme_id는 저장되지 않는다.', async () => {
+      const dto: CreateDiaryDto = {
+        use_theme: false,
+        title: '테스트 제목',
+        content: '테스트 내용',
+      };
+      const toSaveEntity: DiaryEntity = new DiaryEntity({
+        theme_id: undefined,
+        title: dto.title,
+        content: dto.content,
+      });
+      const saveReturnEntity: DiaryEntity = new DiaryEntity({
+        id: '1',
+        theme_id: undefined,
+        title: '테스트 제목',
+        content: '테스트 내용',
+        created_at: new Date(),
+      });
+
+      const expected: DiaryDto = {
+        id: saveReturnEntity.id,
+        title: saveReturnEntity.title,
+        content: saveReturnEntity.content,
+        created_at: saveReturnEntity.created_at,
+      };
+      const saveMock = mockRepository.save.mockResolvedValue(saveReturnEntity);
+
+      const actual = await service.create(dto);
+
+      expect(actual).toEqual(expected);
+      expect(getTodayThemeMock).toHaveBeenCalledTimes(0);
+      expect(saveMock).toHaveBeenCalledWith(toSaveEntity);
+      expect(saveMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/modules/diary/diary.service.ts
+++ b/src/modules/diary/diary.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DiaryRepository } from '@diary/diary.repository';
+import { ThemeService } from '@theme/theme.service';
+import { DiaryMapper } from '@diary/diary.mapper';
+import { CreateDiaryDto } from '@diary/dto/create-diary.dto';
+import { DiaryDto } from '@diary/dto/diary.dto';
+
+@Injectable()
+export class DiaryService {
+  private readonly logger = new Logger(DiaryService.name);
+
+  constructor(
+    private readonly themeService: ThemeService,
+    private readonly diaryRepository: DiaryRepository,
+  ) {}
+
+  async create(createDiaryDto: CreateDiaryDto): Promise<DiaryDto> {
+    this.logger.log(`create : ${createDiaryDto.title}`);
+    const entity = DiaryMapper.createDtoToEntity(createDiaryDto);
+
+    if (createDiaryDto.use_theme)
+      entity.theme_id = this.themeService.getTodayTheme().id;
+
+    const createdEntity = await this.diaryRepository.save(entity);
+    return DiaryMapper.toDto(createdEntity);
+  }
+}

--- a/src/modules/diary/dto/create-diary.dto.ts
+++ b/src/modules/diary/dto/create-diary.dto.ts
@@ -1,0 +1,21 @@
+import {
+  IsBoolean,
+  IsString, Length,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateDiaryDto {
+  @IsBoolean()
+  @ApiProperty({ description: '오늘의 주제 사용 여부', example: true })
+  use_theme: boolean;
+
+  @IsString()
+  @Length(1, 100)
+  @ApiProperty({ description: '일기 제목', example: '일기 제목 샘플' })
+  title: string;
+
+  @IsString()
+  @Length(10, 2000)
+  @ApiProperty({ description: '일기 내용', example: '일기 내용 샘플입니다.' })
+  content: string;
+}

--- a/src/modules/diary/dto/diary.dto.ts
+++ b/src/modules/diary/dto/diary.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class DiaryDto {
+  @ApiProperty({ description: '일기 고유 아이디' })
+  @Expose()
+  readonly id: string;
+
+  @ApiProperty({ description: '일기 제목' })
+  @Expose()
+  readonly title: string;
+
+  @ApiProperty({ description: '일기 내용' })
+  @Expose()
+  readonly content: string;
+
+  @ApiProperty({ description: '일기 작성 일자' })
+  @Expose()
+  readonly created_at: Date;
+}

--- a/src/modules/diary/dto/index.ts
+++ b/src/modules/diary/dto/index.ts
@@ -1,0 +1,2 @@
+export { DiaryDto } from './diary.dto';
+export { CreateDiaryDto } from './create-diary.dto';

--- a/src/modules/diary/entities/diary.entity.ts
+++ b/src/modules/diary/entities/diary.entity.ts
@@ -1,0 +1,22 @@
+import { Exclude, Expose } from 'class-transformer';
+
+export class DiaryEntity {
+  @Expose()
+  id: string;
+
+  @Exclude()
+  theme_id: string;
+
+  @Expose()
+  title: string;
+
+  @Expose()
+  content: string;
+
+  @Expose()
+  created_at: Date;
+
+  constructor(diary: Partial<DiaryEntity>) {
+    Object.assign(this, diary);
+  }
+}

--- a/src/modules/diary/entities/index.ts
+++ b/src/modules/diary/entities/index.ts
@@ -1,0 +1,1 @@
+export { DiaryEntity } from './diary.entity';

--- a/src/modules/diary/interfaces/diary.repository.interface.ts
+++ b/src/modules/diary/interfaces/diary.repository.interface.ts
@@ -1,0 +1,5 @@
+import { DiaryEntity } from '@diary/entities';
+
+export interface DiaryRepositoryBase {
+  save(diaryEntity: DiaryEntity): Promise<DiaryEntity>;
+}

--- a/src/modules/diary/responses/create-diary.response.ts
+++ b/src/modules/diary/responses/create-diary.response.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DiaryDto } from '@diary/dto/diary.dto';
+
+export class CreateDiaryResponse {
+  @ApiProperty({ description: '일기' })
+  diary: DiaryDto;
+}

--- a/src/modules/diary/responses/index.ts
+++ b/src/modules/diary/responses/index.ts
@@ -1,0 +1,1 @@
+export { CreateDiaryResponse } from './create-diary.response';

--- a/src/modules/diary/swagger/create-diary.swagger.ts
+++ b/src/modules/diary/swagger/create-diary.swagger.ts
@@ -1,0 +1,15 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiOperation,
+  getSchemaPath,
+} from '@nestjs/swagger';
+
+import { CreateDiaryResponse } from '@diary/responses';
+
+export function ApiCreateDiaryResponses() {
+  return applyDecorators(
+    ApiOperation({ description: '일기를 생성합니다.' }),
+    ApiCreatedResponse({ description: '일기 생성에 성공했을 경우', schema: { $ref: getSchemaPath(CreateDiaryResponse) } }),
+  );
+}

--- a/src/modules/diary/swagger/index.ts
+++ b/src/modules/diary/swagger/index.ts
@@ -1,0 +1,1 @@
+export { ApiCreateDiaryResponses } from './create-diary.swagger';

--- a/src/modules/me/me.controller.spec.ts
+++ b/src/modules/me/me.controller.spec.ts
@@ -1,0 +1,62 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { MeController } from '@me/me.controller';
+import { DiaryService } from '@diary/diary.service';
+import { CreateDiaryResponse } from '@diary/responses';
+import { CreateDiaryDto } from '@diary/dto';
+
+describe('MeController', () => {
+  let controller: MeController;
+  let mockDiaryService: MockProxy<DiaryService>;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MeController],
+      providers: [DiaryService],
+    })
+      .overrideProvider(DiaryService)
+      .useValue(mock<DiaryService>())
+      .compile();
+
+    controller = module.get<MeController>(MeController);
+    mockDiaryService = module.get(DiaryService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createDiary', () => {
+    it('일기를 생성한다.', async () => {
+      const dto: CreateDiaryDto = {
+        use_theme: true,
+        title: '테스트 일기',
+        content: '테스트 내용',
+      };
+      const expected: CreateDiaryResponse = {
+        diary: {
+          id: '1',
+          title: '테스트 일기',
+          content: '테스트 내용',
+          created_at: new Date(),
+        },
+      };
+      const diaryCreateMock = mockDiaryService.create.mockResolvedValue({
+        id: '1',
+        title: dto.title,
+        content: dto.content,
+        created_at: new Date(),
+      });
+
+      const actual = await controller.createDiary(dto);
+
+      expect(diaryCreateMock).toHaveBeenCalledWith(dto);
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/modules/me/me.controller.ts
+++ b/src/modules/me/me.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
+
+import { DiaryService } from '@diary/diary.service';
+import { CreateDiaryResponse } from '@diary/responses';
+import { CreateDiaryDto } from '@diary/dto';
+import { ApiCreateDiaryResponses } from '@diary/swagger';
+
+@ApiTags('Me')
+@ApiExtraModels(CreateDiaryResponse)
+@Controller('me')
+export class MeController {
+  constructor(
+    private readonly diaryService: DiaryService,
+  ) {}
+
+  @Post('diaries')
+  @ApiCreateDiaryResponses()
+  async createDiary(
+    @Body() createDiaryDto: CreateDiaryDto,
+  ): Promise<CreateDiaryResponse> {
+    const diary = await this.diaryService.create(createDiaryDto);
+
+    return {
+      diary,
+    };
+  }
+}

--- a/src/modules/me/me.module.ts
+++ b/src/modules/me/me.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { DiaryModule } from '@diary/diary.module';
+import { MeController } from '@me/me.controller';
+
+@Module({
+  imports: [DiaryModule],
+  controllers: [MeController],
+})
+export class MeModule {}

--- a/src/modules/theme/theme.controller.spec.ts
+++ b/src/modules/theme/theme.controller.spec.ts
@@ -27,11 +27,14 @@ describe('ThemeController', () => {
   });
 
   describe('today', () => {
-    const theme = '오늘의 주제';
+    const theme = {
+      id: '1',
+      text: '오늘의 주제',
+    };
 
     it('서비스에서 받은 오늘의 주제를 응답의 형식에 맞게 반환한다.', () => {
       const expected: TodayThemeResponse = {
-        theme,
+        theme: theme.text,
       };
       const getTodayThemeMock = service.getTodayTheme.mockReturnValue(theme);
 

--- a/src/modules/theme/theme.controller.ts
+++ b/src/modules/theme/theme.controller.ts
@@ -21,10 +21,10 @@ export class ThemeController {
   @HttpCode(HttpStatus.OK)
   @ApiTodayResponses()
   today(): TodayThemeResponse {
-    const theme = this.themeService.getTodayTheme();
+    const { text } = this.themeService.getTodayTheme();
 
     return {
-      theme,
+      theme: text,
     };
   }
 }

--- a/src/modules/theme/theme.module.ts
+++ b/src/modules/theme/theme.module.ts
@@ -12,5 +12,6 @@ import { ThemeRepository } from '@theme/theme.repository';
     ThemeRepository,
     ThemeScheduler,
   ],
+  exports: [ThemeService],
 })
 export class ThemeModule {}

--- a/src/modules/theme/theme.service.spec.ts
+++ b/src/modules/theme/theme.service.spec.ts
@@ -37,16 +37,19 @@ describe('ThemeService', () => {
   });
 
   describe('getTodayTheme', () => {
-    const theme = '오늘의 주제';
+    const theme: ThemeEntity = {
+      id: '1',
+      text: '오늘의 주제',
+    };
     it('오늘의 주제를 정상적으로 반환한다.', async () => {
-      const expected = theme;
-      mockRepository.getRandomTheme.mockResolvedValue({ id: '1', text: theme });
+      const expected = '오늘의 주제';
+      mockRepository.getRandomTheme.mockResolvedValue(theme);
       mockConfigService.get.mockReturnValue(Environment.Test);
       await service.onModuleInit();
 
       const actual = service.getTodayTheme();
 
-      expect(actual).toEqual(expected);
+      expect(actual.text).toEqual(expected);
     });
   });
 
@@ -85,7 +88,7 @@ describe('ThemeService', () => {
       expect(mockGetLastLog).toHaveBeenCalled();
       expect(mockConfigGet).not.toHaveBeenCalled();
       expect(mockGetRandomTheme).toHaveBeenCalled();
-      expect(result).toEqual(themeEntity.text);
+      expect(result.text).toEqual(themeEntity.text);
     });
 
     it('로그가 존재하며, 오늘이 지났을 경우 오늘의 주제를 새롭게 설정한다.', async () => {
@@ -105,7 +108,7 @@ describe('ThemeService', () => {
 
       expect(mockGetRandomTheme).toHaveBeenCalled();
       expect(mockSaveLog).toHaveBeenCalledWith(themeEntity);
-      expect(result).toEqual(themeEntity.text);
+      expect(result.text).toEqual(themeEntity.text);
       expect(mockFindById).not.toHaveBeenCalled();
     });
 
@@ -126,7 +129,7 @@ describe('ThemeService', () => {
 
       expect(mockGetRandomTheme).not.toHaveBeenCalled();
       expect(mockSaveLog).not.toHaveBeenCalled();
-      expect(result).toEqual(themeEntity.text);
+      expect(result.text).toEqual(themeEntity.text);
       expect(mockFindById).toHaveBeenCalled();
     });
   });

--- a/src/modules/theme/theme.service.ts
+++ b/src/modules/theme/theme.service.ts
@@ -21,8 +21,8 @@ export class ThemeService implements OnModuleInit {
     await this.triggerUpdateTodayTheme();
   }
 
-  getTodayTheme(): string {
-    return this.todayTheme.text;
+  getTodayTheme(): ThemeEntity {
+    return this.todayTheme;
   }
 
   async updateTodayTheme(): Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "baseUrl": "./",
     "paths": {
       "@common/*": ["./src/common/*"],
-      "@theme/*": ["./src/modules/theme/*"]
+      "@theme/*": ["./src/modules/theme/*"],
+      "@diary/*": ["./src/modules/diary/*"],
+      "@me/*": ["./src/modules/me/*"]
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 변경 사항 요약 (Summary)

- POST /me/diaries로 사용이 가능합니다
- me, diary에 관한 paths가 추가되었습니다.
- diary API 구현에 따라 ThemeService의 반환값이 변했습니다. 이제 엔티티 자체를 반환합니다.
- 글로벌 ValidationPipe가 추가되었습니다.

## 관련 이슈 (Related Issues)

- Closes #11

## 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.