### PR TITLE
#13 feat(diary): 최근 일기 조회 API

### DIFF
--- a/src/modules/diary/diary.controller.spec.ts
+++ b/src/modules/diary/diary.controller.spec.ts
@@ -10,6 +10,14 @@ describe('DiaryController', () => {
   let controller: DiaryController;
   let mockService: MockProxy<DiaryService>;
 
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DiaryController],

--- a/src/modules/diary/diary.controller.spec.ts
+++ b/src/modules/diary/diary.controller.spec.ts
@@ -1,7 +1,7 @@
 import { mock, MockProxy } from 'jest-mock-extended';
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { DiaryController } from '@diary//diary.controller';
+import { DiaryController } from '@diary/diary.controller';
 import { DiaryService } from '@diary/diary.service';
 import { DiaryDto } from '@diary/dto';
 import { GetRecentDiaryResponse } from '@diary/responses';

--- a/src/modules/diary/diary.controller.spec.ts
+++ b/src/modules/diary/diary.controller.spec.ts
@@ -1,0 +1,75 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DiaryController } from '@diary//diary.controller';
+import { DiaryService } from '@diary/diary.service';
+import { DiaryDto } from '@diary/dto';
+import { GetRecentDiaryResponse } from '@diary/responses';
+
+describe('DiaryController', () => {
+  let controller: DiaryController;
+  let mockService: MockProxy<DiaryService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DiaryController],
+      providers: [DiaryService],
+    })
+      .overrideProvider(DiaryService)
+      .useValue(mock<DiaryService>())
+      .compile();
+
+    controller = module.get<DiaryController>(DiaryController);
+    mockService = module.get(DiaryService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('recent', () => {
+    it('가장 최근 5개의 일기 목록을 반환한다.', async () => {
+      const diaries: DiaryDto[] = [
+        {
+          id: '1',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '2',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '3',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '4',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '5',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+      ];
+      const expected: GetRecentDiaryResponse = {
+        diaries,
+      };
+      mockService.findByRecent.mockResolvedValue(diaries);
+
+      const actual = await controller.recent();
+
+      expect(actual.diaries).toHaveLength(5);
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/modules/diary/diary.controller.ts
+++ b/src/modules/diary/diary.controller.ts
@@ -1,0 +1,29 @@
+import {
+  Controller, Get,
+  HttpCode, HttpStatus,
+} from '@nestjs/common';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
+
+import { DiaryService } from '@diary/diary.service';
+import { GetRecentDiaryResponse } from '@diary/responses';
+import { ApiGetRecentDiaryResponses } from '@diary/swagger';
+
+@ApiTags('Diary')
+@ApiExtraModels(GetRecentDiaryResponse)
+@Controller('diaries')
+export class DiaryController {
+  constructor(
+    private readonly diaryService: DiaryService,
+  ) {}
+
+  @Get('recent')
+  @HttpCode(HttpStatus.OK)
+  @ApiGetRecentDiaryResponses()
+  async recent(): Promise<GetRecentDiaryResponse> {
+    const diaries = await this.diaryService.findByRecent();
+
+    return {
+      diaries,
+    };
+  }
+}

--- a/src/modules/diary/diary.module.ts
+++ b/src/modules/diary/diary.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ThemeModule } from '@theme/theme.module';
 import { DiaryService } from '@diary/diary.service';
 import { DiaryRepository } from '@diary/diary.repository';
+import { DiaryController } from './diary.controller';
 
 @Module({
   imports: [ThemeModule],
@@ -11,5 +12,6 @@ import { DiaryRepository } from '@diary/diary.repository';
     DiaryRepository,
   ],
   exports: [DiaryService],
+  controllers: [DiaryController],
 })
 export class DiaryModule {}

--- a/src/modules/diary/diary.repository.ts
+++ b/src/modules/diary/diary.repository.ts
@@ -5,8 +5,23 @@ import { DiaryEntity } from '@diary/entities';
 
 @Injectable()
 export class DiaryRepository implements DiaryRepositoryBase {
-  private diaries: DiaryEntity[] = [];
-  private diaryId = 0;
+  private diaries: DiaryEntity[] = [
+    {
+      id: '1',
+      theme_id: '1',
+      title: '일기 제목 샘플',
+      content: '일기 내용 샘플입니다.',
+      created_at: new Date(),
+    },
+    {
+      id: '2',
+      theme_id: null,
+      title: '일기 제목 샘플',
+      content: '일기 내용 샘플입니다.',
+      created_at: new Date(),
+    },
+  ];
+  private diaryId = 2;
   constructor() {}
 
   async save(diaryEntity: DiaryEntity): Promise<DiaryEntity> {
@@ -25,5 +40,9 @@ export class DiaryRepository implements DiaryRepositoryBase {
       return Promise.reject(new Error('Database Error'));
     else
       return Promise.resolve(createdEntity);
+  }
+
+  async findByRecent(): Promise<DiaryEntity[]> {
+    return Promise.resolve(this.diaries.slice(-5));
   }
 }

--- a/src/modules/diary/diary.service.spec.ts
+++ b/src/modules/diary/diary.service.spec.ts
@@ -119,4 +119,85 @@ describe('DiaryService', () => {
       expect(saveMock).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('findByRecent', () => {
+    const diaryEntities: DiaryEntity[] = [
+      {
+        id: '1',
+        theme_id: null,
+        title: '일기 제목 샘플',
+        content: '일기 내용 샘플입니다.',
+        created_at: new Date(),
+      },
+      {
+        id: '2',
+        theme_id: null,
+        title: '일기 제목 샘플',
+        content: '일기 내용 샘플입니다.',
+        created_at: new Date(),
+      },
+      {
+        id: '3',
+        theme_id: null,
+        title: '일기 제목 샘플',
+        content: '일기 내용 샘플입니다.',
+        created_at: new Date(),
+      },
+      {
+        id: '4',
+        theme_id: null,
+        title: '일기 제목 샘플',
+        content: '일기 내용 샘플입니다.',
+        created_at: new Date(),
+      },
+      {
+        id: '5',
+        theme_id: null,
+        title: '일기 제목 샘플',
+        content: '일기 내용 샘플입니다.',
+        created_at: new Date(),
+      },
+    ];
+
+    it('가장 최근 일기 5개를 반환합니다.', async () => {
+      const expected: DiaryDto[] = [
+        {
+          id: '1',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '2',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '3',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '4',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '5',
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+      ];
+      mockRepository.findByRecent.mockResolvedValue(diaryEntities);
+
+      const actual = await service.findByRecent();
+
+      expect(actual).toHaveLength(5);
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/src/modules/diary/diary.service.spec.ts
+++ b/src/modules/diary/diary.service.spec.ts
@@ -13,10 +13,6 @@ describe('DiaryService', () => {
   let mockRepository: MockProxy<DiaryRepository>;
   let mockThemeService: MockProxy<ThemeService>;
 
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -34,6 +30,12 @@ describe('DiaryService', () => {
     service = module.get<DiaryService>(DiaryService);
     mockRepository = module.get(DiaryRepository);
     mockThemeService = module.get(ThemeService);
+
+    jest.useFakeTimers().setSystemTime();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('should be defined', () => {
@@ -121,43 +123,47 @@ describe('DiaryService', () => {
   });
 
   describe('findByRecent', () => {
-    const diaryEntities: DiaryEntity[] = [
-      {
-        id: '1',
-        theme_id: null,
-        title: '일기 제목 샘플',
-        content: '일기 내용 샘플입니다.',
-        created_at: new Date(),
-      },
-      {
-        id: '2',
-        theme_id: null,
-        title: '일기 제목 샘플',
-        content: '일기 내용 샘플입니다.',
-        created_at: new Date(),
-      },
-      {
-        id: '3',
-        theme_id: null,
-        title: '일기 제목 샘플',
-        content: '일기 내용 샘플입니다.',
-        created_at: new Date(),
-      },
-      {
-        id: '4',
-        theme_id: null,
-        title: '일기 제목 샘플',
-        content: '일기 내용 샘플입니다.',
-        created_at: new Date(),
-      },
-      {
-        id: '5',
-        theme_id: null,
-        title: '일기 제목 샘플',
-        content: '일기 내용 샘플입니다.',
-        created_at: new Date(),
-      },
-    ];
+    let diaryEntities: DiaryEntity[];
+
+    beforeEach(() => {
+      diaryEntities = [
+        {
+          id: '1',
+          theme_id: null,
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '2',
+          theme_id: null,
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '3',
+          theme_id: null,
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '4',
+          theme_id: null,
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+        {
+          id: '5',
+          theme_id: null,
+          title: '일기 제목 샘플',
+          content: '일기 내용 샘플입니다.',
+          created_at: new Date(),
+        },
+      ];
+    });
 
     it('가장 최근 일기 5개를 반환합니다.', async () => {
       const expected: DiaryDto[] = [

--- a/src/modules/diary/diary.service.ts
+++ b/src/modules/diary/diary.service.ts
@@ -24,4 +24,12 @@ export class DiaryService {
     const createdEntity = await this.diaryRepository.save(entity);
     return DiaryMapper.toDto(createdEntity);
   }
+
+  async findByRecent(): Promise<DiaryDto[]> {
+    this.logger.log('findByRecent');
+
+    const recentDiaries = await this.diaryRepository.findByRecent();
+
+    return recentDiaries.map((diary) => DiaryMapper.toDto(diary));
+  }
 }

--- a/src/modules/diary/entities/diary.entity.ts
+++ b/src/modules/diary/entities/diary.entity.ts
@@ -5,7 +5,7 @@ export class DiaryEntity {
   id: string;
 
   @Exclude()
-  theme_id: string;
+  theme_id: string | null;
 
   @Expose()
   title: string;

--- a/src/modules/diary/interfaces/diary.repository.interface.ts
+++ b/src/modules/diary/interfaces/diary.repository.interface.ts
@@ -2,4 +2,5 @@ import { DiaryEntity } from '@diary/entities';
 
 export interface DiaryRepositoryBase {
   save(diaryEntity: DiaryEntity): Promise<DiaryEntity>;
+  findByRecent(): Promise<DiaryEntity[]>
 }

--- a/src/modules/diary/interfaces/diary.repository.interface.ts
+++ b/src/modules/diary/interfaces/diary.repository.interface.ts
@@ -2,5 +2,5 @@ import { DiaryEntity } from '@diary/entities';
 
 export interface DiaryRepositoryBase {
   save(diaryEntity: DiaryEntity): Promise<DiaryEntity>;
-  findByRecent(): Promise<DiaryEntity[]>
+  findByRecent(): Promise<DiaryEntity[]>;
 }

--- a/src/modules/diary/responses/get-recent-diary.response.ts
+++ b/src/modules/diary/responses/get-recent-diary.response.ts
@@ -1,0 +1,11 @@
+import { DiaryDto } from '@diary/dto';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetRecentDiaryResponse {
+  @ApiProperty({
+    description: '가장 최근에 작성된 일기 목록',
+    type: DiaryDto,
+    isArray: true,
+  })
+  diaries: DiaryDto[];
+}

--- a/src/modules/diary/responses/index.ts
+++ b/src/modules/diary/responses/index.ts
@@ -1,1 +1,2 @@
 export { CreateDiaryResponse } from './create-diary.response';
+export { GetRecentDiaryResponse } from './get-recent-diary.response';

--- a/src/modules/diary/swagger/get-recent-diary.swagger.ts
+++ b/src/modules/diary/swagger/get-recent-diary.swagger.ts
@@ -1,0 +1,15 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  getSchemaPath,
+} from '@nestjs/swagger';
+
+import { GetRecentDiaryResponse } from '@diary/responses';
+
+export function ApiGetRecentDiaryResponses() {
+  return applyDecorators(
+    ApiOperation({ description: '가장 최근에 작성된 일기를 반환합니다.' }),
+    ApiOkResponse({ description: '요청이 성공 했을 경우', schema: { $ref: getSchemaPath(GetRecentDiaryResponse) } }),
+  );
+}

--- a/src/modules/diary/swagger/index.ts
+++ b/src/modules/diary/swagger/index.ts
@@ -1,1 +1,2 @@
 export { ApiCreateDiaryResponses } from './create-diary.swagger';
+export { ApiGetRecentDiaryResponses } from './get-recent-diary.swagger';

--- a/src/modules/me/me.controller.spec.ts
+++ b/src/modules/me/me.controller.spec.ts
@@ -11,7 +11,11 @@ describe('MeController', () => {
   let mockDiaryService: MockProxy<DiaryService>;
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    jest.useFakeTimers().setSystemTime();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
## 변경 사항 요약 (Summary)

- 최근 작성된 일기 5개를 반환합니다.
- /diaries/recent로 요청 가능합니다.

## 관련 이슈 (Related Issues)

- Closes #13
- Related #이슈번호

## 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.