### PR TITLE
#19 feat(diary): 일기 수정 API

### DIFF
--- a/src/common/utils/date.spec.ts
+++ b/src/common/utils/date.spec.ts
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+
+import { DateUtil } from '@common/utils/date';
+
+describe('DateUtil', () => {
+  describe('hasExpired', () => {
+    it('현재 시간이 기준 시간 이전이면 false를 반환한다', () => {
+      const target = new Date('2025-01-01T14:00:00+09:00');
+      const now = dayjs('2025-01-02T03:59:00+09:00');
+
+      const result = DateUtil.hasExpired(target, now);
+      expect(result).toBe(false);
+    });
+
+    it('현재 시간이 기준 시간과 완벽히 동일하다면 false 반환한다', () => {
+      const target = new Date('2025-01-01T00:00:00+09:00');
+      const now = dayjs('2025-01-02T04:00:00+09:00');
+
+      const result = DateUtil.hasExpired(target, now);
+      expect(result).toBe(false);
+    });
+
+    it('현재 시간이 기준 시간 이후이면 true를 반환한다', () => {
+      const target = new Date('2025-01-01T14:00:00+09:00');
+      const now = dayjs('2025-01-02T05:00:00+09:00');
+
+      const result = DateUtil.hasExpired(target, now);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -6,6 +6,19 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.tz.setDefault('Asia/Seoul');
 
-export function hasTimePassed(target: Date, unit: dayjs.UnitType, threshold: number): boolean {
-  return dayjs().diff(dayjs(target), unit) >= threshold;
+export class DateUtil {
+  static now() {
+    return dayjs().toDate();
+  }
+
+  static hasExpired(target: Date, now: dayjs.Dayjs = dayjs()) {
+    const expireDate = dayjs(target)
+      .add(1, 'day')
+      .set('hour', 4)
+      .set('minute', 0)
+      .set('second', 0)
+      .set('millisecond', 0);
+
+    return now.isAfter(expireDate);
+  }
 }

--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -11,6 +11,20 @@ export class DateUtil {
     return dayjs().toDate();
   }
 
+  static date(
+    year?: number,
+    month: number = 0,
+    day: number = 1,
+    hour: number = 0,
+    minute: number = 0,
+    second: number = 0
+  ): Date {
+    if (!year)
+      return this.now();
+    return dayjs(new Date(year, month, day, hour, minute, second)).toDate();
+  }
+
+
   static hasExpired(target: Date, now: dayjs.Dayjs = dayjs()) {
     const expireDate = dayjs(target)
       .add(1, 'day')

--- a/src/modules/diary/decorator/api-update-diary.decorator.ts
+++ b/src/modules/diary/decorator/api-update-diary.decorator.ts
@@ -1,0 +1,20 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+
+export function ApiUpdateDiaryResponses() {
+  return applyDecorators(
+    ApiOperation({ description: '일기 제목 및 내용을 수정합니다.' }),
+    ApiNoContentResponse({ description: '일기를 성공적으로 수정한 경우' }),
+    ApiNotFoundResponse({ description: '해당 ID의 일기가 존재하지 않을 경우' }),
+    ApiUnauthorizedResponse({ description: '인증되지 않은 사용자일 경우' }),
+    ApiForbiddenResponse({ description: '자신의 일기가 아닌 다른 사람의 일기를 수정하려는 경우' }),
+    ApiUnprocessableEntityResponse({ description: '오늘의 일기가 아닌 다른 날짜의 일기를 수정하려는 경우' })
+  );
+}

--- a/src/modules/diary/diary.repository.ts
+++ b/src/modules/diary/diary.repository.ts
@@ -1,5 +1,5 @@
 import { Repository } from 'typeorm';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { DiaryRepositoryBase } from '@diary/interfaces';
@@ -7,6 +7,7 @@ import { DiaryEntity } from '@diary/entities';
 
 @Injectable()
 export class DiaryRepository implements DiaryRepositoryBase {
+  private readonly logger = new Logger(DiaryRepository.name);
   constructor(
     @InjectRepository(DiaryEntity)
     private readonly repository: Repository<DiaryEntity>,
@@ -18,6 +19,22 @@ export class DiaryRepository implements DiaryRepositoryBase {
 
   async save(diaryEntity: DiaryEntity): Promise<DiaryEntity> {
     return this.repository.save(diaryEntity);
+  }
+
+  async update(diaryEntity: DiaryEntity): Promise<void> {
+    const { id, title, content } = diaryEntity;
+
+    const queryBuilder = this.repository.createQueryBuilder()
+      .update()
+      .set({ title, content })
+      .where('id = :id', { id });
+    await queryBuilder.execute();
+  }
+
+  async findById(id: string) {
+    return this.repository.findOneBy({
+      id,
+    });
   }
 
   async findByRecent(): Promise<DiaryEntity[]> {

--- a/src/modules/diary/diary.service.spec.ts
+++ b/src/modules/diary/diary.service.spec.ts
@@ -67,7 +67,7 @@ describe('DiaryService', () => {
     let getTodayThemeMock: () => ThemeEntity;
 
     beforeEach(() => {
-      themeEntity = { id: '4', text: '오늘의 주제' };
+      themeEntity = { id: 4, text: '오늘의 주제' };
       getTodayThemeMock = mockThemeService.getTodayTheme.mockReturnValue(themeEntity);
     });
 

--- a/src/modules/diary/dto/index.ts
+++ b/src/modules/diary/dto/index.ts
@@ -1,3 +1,6 @@
 export { DiaryDto } from './diary.dto';
 export { CreateDiaryDto } from './create-diary.dto';
+export { UpdateDiaryDto } from './update-diary.dto';
+export { UpdateDiaryParam } from './update-diary-param.dto';
+export { UpdateDiaryBody } from './update-diary-body.dto';
 export { DeleteDiaryDto } from './delete-diary.dto';

--- a/src/modules/diary/dto/update-diary-body.dto.ts
+++ b/src/modules/diary/dto/update-diary-body.dto.ts
@@ -1,0 +1,4 @@
+import { OmitType } from '@nestjs/swagger';
+import { CreateDiaryDto } from '@diary/dto/create-diary.dto';
+
+export class UpdateDiaryBody extends OmitType(CreateDiaryDto, ['use_theme']) {}

--- a/src/modules/diary/dto/update-diary-param.dto.ts
+++ b/src/modules/diary/dto/update-diary-param.dto.ts
@@ -1,0 +1,8 @@
+import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateDiaryParam {
+  @IsUUID()
+  @ApiProperty({ description: '일기 고유 아이디' })
+  id: string;
+}

--- a/src/modules/diary/dto/update-diary.dto.ts
+++ b/src/modules/diary/dto/update-diary.dto.ts
@@ -1,0 +1,18 @@
+import {
+  UpdateDiaryParam,
+  UpdateDiaryBody,
+} from '@diary/dto';
+
+export class UpdateDiaryDto {
+  id: string;
+  title: string;
+  content: string;
+
+  static of(param: UpdateDiaryParam, body: UpdateDiaryBody) {
+    const dto = new UpdateDiaryDto();
+    dto.id = param.id;
+    dto.title = body.title;
+    dto.content = body.content;
+    return dto;
+  }
+}

--- a/src/modules/diary/exceptions/diary-edit-expired-exception.ts
+++ b/src/modules/diary/exceptions/diary-edit-expired-exception.ts
@@ -1,0 +1,8 @@
+import { ServiceException } from '@common/exception';
+import { HttpStatus } from '@nestjs/common';
+
+export class DiaryEditExpiredException extends ServiceException {
+  constructor() {
+    super(HttpStatus.UNPROCESSABLE_ENTITY, '수정가능한 시간이 지났습니다.');
+  }
+}

--- a/src/modules/diary/exceptions/index.ts
+++ b/src/modules/diary/exceptions/index.ts
@@ -1,1 +1,2 @@
 export { DiaryNotFoundException } from './diary-not-found-exception';
+export { DiaryEditExpiredException } from './diary-edit-expired-exception';

--- a/src/modules/me/me.controller.spec.ts
+++ b/src/modules/me/me.controller.spec.ts
@@ -4,7 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MeController } from '@me/me.controller';
 import { DiaryService } from '@diary/diary.service';
 import { CreateDiaryResponse } from '@diary/responses';
-import { CreateDiaryDto, DeleteDiaryDto } from '@diary/dto';
+import { CreateDiaryDto, DeleteDiaryDto, UpdateDiaryBody, UpdateDiaryDto, UpdateDiaryParam } from '@diary/dto';
 
 describe('MeController', () => {
   let controller: MeController;
@@ -61,6 +61,29 @@ describe('MeController', () => {
 
       expect(diaryCreateMock).toHaveBeenCalledWith(dto);
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('updateDiary', () => {
+    it('일기를 수정한다.', async () => {
+      const updateDiaryParam: UpdateDiaryParam = {
+        id: 'id',
+      };
+      const updateDiaryBody: UpdateDiaryBody = {
+        title: '일기 제목',
+        content: '일기 내용',
+      };
+      const updateDiaryDto: UpdateDiaryDto = {
+        ...updateDiaryParam,
+        ...updateDiaryBody,
+      };
+
+      const mockUpdate = mockDiaryService.update.mockResolvedValue();
+
+      await controller.updateDiary(updateDiaryParam, updateDiaryBody);
+
+      expect(mockUpdate).toHaveBeenCalledWith(updateDiaryDto);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/modules/me/me.controller.ts
+++ b/src/modules/me/me.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Delete, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, HttpCode, HttpStatus, Param, Patch, Post } from '@nestjs/common';
 import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 
 import { DiaryService } from '@diary/diary.service';
 import { CreateDiaryResponse } from '@diary/responses';
-import { CreateDiaryDto, DeleteDiaryDto } from '@diary/dto';
+import { CreateDiaryDto, DeleteDiaryDto, UpdateDiaryDto } from '@diary/dto';
 import { ApiCreateDiaryResponses, ApiDeleteDiaryResponses } from '@diary/decorator';
+import { ApiUpdateDiaryResponses } from '@diary/decorator/api-update-diary.decorator';
+import { UpdateDiaryBody } from '@diary/dto/update-diary-body.dto';
+import { UpdateDiaryParam } from '@diary/dto/update-diary-param.dto';
 
 @ApiTags('Me')
 @ApiExtraModels(CreateDiaryResponse)
@@ -25,6 +28,18 @@ export class MeController {
     return {
       diary,
     };
+  }
+
+  @Patch('diaries/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiUpdateDiaryResponses()
+  async updateDiary(
+    @Param() updateDiaryParam: UpdateDiaryParam,
+    @Body() updateDiaryBody: UpdateDiaryBody,
+  ): Promise<void> {
+    const updateDiaryDto = UpdateDiaryDto.of(updateDiaryParam, updateDiaryBody);
+
+    await this.diaryService.update(updateDiaryDto);
   }
 
   @Delete('diaries/:id')

--- a/src/modules/theme/entities/theme-log.entity.ts
+++ b/src/modules/theme/entities/theme-log.entity.ts
@@ -3,7 +3,7 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
-  PrimaryGeneratedColumn, RelationId,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ThemeEntity } from '@theme/entities';
 
@@ -15,9 +15,6 @@ export class ThemeLogEntity {
   @ManyToOne(() => ThemeEntity, { nullable: false })
   @JoinColumn({ name: 'theme_id' })
   theme: ThemeEntity;
-
-  @RelationId((log: ThemeLogEntity) => log.theme)
-  themeId: number;
 
   @CreateDateColumn({ type: 'timestamp', name: 'logged_date' })
   loggedDate: Date;

--- a/src/modules/theme/entities/theme-log.entity.ts
+++ b/src/modules/theme/entities/theme-log.entity.ts
@@ -3,7 +3,7 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
-  PrimaryGeneratedColumn,
+  PrimaryGeneratedColumn, RelationId,
 } from 'typeorm';
 import { ThemeEntity } from '@theme/entities';
 
@@ -15,6 +15,9 @@ export class ThemeLogEntity {
   @ManyToOne(() => ThemeEntity, { nullable: false })
   @JoinColumn({ name: 'theme_id' })
   theme: ThemeEntity;
+
+  @RelationId((log: ThemeLogEntity) => log.theme)
+  themeId: number;
 
   @CreateDateColumn({ type: 'timestamp', name: 'logged_date' })
   loggedDate: Date;

--- a/src/modules/theme/entities/theme.entity.ts
+++ b/src/modules/theme/entities/theme.entity.ts
@@ -2,8 +2,8 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'themes' })
 export class ThemeEntity {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+  @PrimaryGeneratedColumn('increment')
+  id: number;
 
   @Column({ type: 'varchar', length: 255, nullable: false, unique: true })
   text: string;

--- a/src/modules/theme/interface/theme.repository.interface.ts
+++ b/src/modules/theme/interface/theme.repository.interface.ts
@@ -1,6 +1,6 @@
 import { ThemeEntity } from '@theme/entities';
 
 export interface ThemeRepositoryBase {
-  findById(id: string): Promise<ThemeEntity | null>;
+  findById(id: number): Promise<ThemeEntity | null>;
   getRandomTheme(): Promise<ThemeEntity>;
 }

--- a/src/modules/theme/theme-log.repository.ts
+++ b/src/modules/theme/theme-log.repository.ts
@@ -24,7 +24,9 @@ export class ThemeLogRepository implements ThemeLogRepositoryBase {
     const [log] = await this.repository.find({
       order: { id: 'DESC' },
       take: 1,
+      relations: ['theme'],
     });
+
     return log ?? null;
   }
 }

--- a/src/modules/theme/theme.controller.spec.ts
+++ b/src/modules/theme/theme.controller.spec.ts
@@ -28,7 +28,7 @@ describe('ThemeController', () => {
 
   describe('today', () => {
     const theme = {
-      id: '1',
+      id: 1,
       text: '오늘의 주제',
     };
 

--- a/src/modules/theme/theme.repository.ts
+++ b/src/modules/theme/theme.repository.ts
@@ -13,7 +13,7 @@ export class ThemeRepository implements ThemeRepositoryBase {
     private readonly repository: Repository<ThemeEntity>
   ) {}
 
-  findById(id: string): Promise<ThemeEntity | null> {
+  findById(id: number): Promise<ThemeEntity | null> {
     return this.repository.findOneBy({
       id,
     });
@@ -24,7 +24,6 @@ export class ThemeRepository implements ThemeRepositoryBase {
       .select()
       .orderBy('RAND()')
       .limit(1);
-    this.logger.debug(`getRandomTheme Sql : ${queryBuilder.getSql()}`);
 
     return queryBuilder.getOneOrFail();
   }

--- a/src/modules/theme/theme.scheduler.ts
+++ b/src/modules/theme/theme.scheduler.ts
@@ -15,7 +15,7 @@ export class ThemeScheduler implements OnModuleInit {
   ) {}
 
   onModuleInit(): void {
-    const cronExpression = CronExpression.EVERY_DAY_AT_4AM
+    const cronExpression = CronExpression.EVERY_DAY_AT_4AM;
 
     const job = new CronJob(cronExpression, () => {
       void this.themeService.triggerUpdateTodayTheme();

--- a/src/modules/theme/theme.scheduler.ts
+++ b/src/modules/theme/theme.scheduler.ts
@@ -1,11 +1,9 @@
 import { CronJob } from 'cron';
 
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { CronExpression, SchedulerRegistry } from '@nestjs/schedule';
 
 import { ThemeService } from '@theme/theme.service';
-import { Environment, EnvironmentVariables } from '@common/env';
 
 @Injectable()
 export class ThemeScheduler implements OnModuleInit {
@@ -13,16 +11,11 @@ export class ThemeScheduler implements OnModuleInit {
 
   constructor(
     private readonly schedulerRegistry: SchedulerRegistry,
-    private readonly configService: ConfigService<EnvironmentVariables, true>,
     private readonly themeService: ThemeService,
   ) {}
 
   onModuleInit(): void {
-    const environment = this.configService.get<Environment>('NODE_ENV');
-
-    const cronExpression = environment === Environment.Development
-      ? CronExpression.EVERY_MINUTE
-      : CronExpression.EVERY_DAY_AT_4AM;
+    const cronExpression = CronExpression.EVERY_DAY_AT_4AM
 
     const job = new CronJob(cronExpression, () => {
       void this.themeService.triggerUpdateTodayTheme();

--- a/src/modules/theme/theme.service.spec.ts
+++ b/src/modules/theme/theme.service.spec.ts
@@ -9,6 +9,7 @@ import { ThemeLogRepository } from '@theme/theme-log.repository';
 import { Environment } from '@common/env';
 import { QueryRunnerFactory } from '@database/query-runner.factory';
 import { ThemeEntity, ThemeLogEntity } from '@theme/entities';
+import { DateUtil } from '@common/utils/date';
 
 describe('ThemeService', () => {
   let service: ThemeService;
@@ -46,6 +47,10 @@ describe('ThemeService', () => {
 
     mockQueryRunner = mock<QueryRunner>();
     mockQueryRunnerFactory.create.mockReturnValue(mockQueryRunner);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('should be defined', () => {
@@ -108,13 +113,14 @@ describe('ThemeService', () => {
     });
 
     it('로그가 존재하며, 오늘이 지났을 경우 오늘의 주제를 새롭게 설정한다.', async () => {
+      jest.useFakeTimers().setSystemTime(DateUtil.date(2025, 4, 2, 5));
       const themeLogEntity: ThemeLogEntity = {
         id: 1,
         theme: {
           id: '1',
           text: '오늘의 주제',
         },
-        loggedDate: new Date('1990-01-01'),
+        loggedDate: DateUtil.date(2025, 4, 1, 4),
       };
       mockThemeLogRepository.getLastLog.mockResolvedValue(themeLogEntity);
       const mockFindById = mockThemeRepository.findById.mockResolvedValue(null);
@@ -132,6 +138,7 @@ describe('ThemeService', () => {
     });
 
     it('로그가 존재하며, 오늘이 지나지 않았을 경우 오늘의 주제를 로그로부터 가져온다.', async () => {
+      jest.useFakeTimers().setSystemTime(DateUtil.date(2025, 4, 2, 3));
       const theme: ThemeEntity = {
         id: '1',
         text: '오늘의 주제',
@@ -139,8 +146,9 @@ describe('ThemeService', () => {
       const themeLogEntity: ThemeLogEntity = {
         id: 1,
         theme,
-        loggedDate: new Date(),
+        loggedDate: DateUtil.date(2025, 4, 1, 4),
       };
+      console.info(themeLogEntity.loggedDate);
       mockThemeLogRepository.getLastLog.mockResolvedValue(themeLogEntity);
       const mockFindById = mockThemeRepository.findById.mockResolvedValue(themeEntity);
       const mockGetRandomTheme = mockThemeRepository.getRandomTheme.mockResolvedValue(theme);

--- a/src/modules/theme/theme.service.spec.ts
+++ b/src/modules/theme/theme.service.spec.ts
@@ -59,7 +59,7 @@ describe('ThemeService', () => {
 
   describe('getTodayTheme', () => {
     const theme: ThemeEntity = {
-      id: '1',
+      id: 1,
       text: '오늘의 주제',
     };
     it('오늘의 주제를 정상적으로 반환한다.', async () => {
@@ -77,7 +77,7 @@ describe('ThemeService', () => {
   describe('updateTodayTheme', () => {
     const theme = '오늘의 주제';
     const themeEntity: ThemeEntity = {
-      id: '1',
+      id: 1,
       text: theme,
     };
     it('오늘의 주제를 업데이트한다.', async () => {
@@ -94,7 +94,7 @@ describe('ThemeService', () => {
   describe('triggerUpdateTodayTheme', () => {
     const theme = '오늘의 주제';
     const themeEntity: ThemeEntity = {
-      id: '1',
+      id: 1,
       text: theme,
     };
 
@@ -117,7 +117,7 @@ describe('ThemeService', () => {
       const themeLogEntity: ThemeLogEntity = {
         id: 1,
         theme: {
-          id: '1',
+          id: 1,
           text: '오늘의 주제',
         },
         loggedDate: DateUtil.date(2025, 4, 1, 4),
@@ -140,7 +140,7 @@ describe('ThemeService', () => {
     it('로그가 존재하며, 오늘이 지나지 않았을 경우 오늘의 주제를 로그로부터 가져온다.', async () => {
       jest.useFakeTimers().setSystemTime(DateUtil.date(2025, 4, 2, 3));
       const theme: ThemeEntity = {
-        id: '1',
+        id: 1,
         text: '오늘의 주제',
       };
       const themeLogEntity: ThemeLogEntity = {
@@ -148,7 +148,7 @@ describe('ThemeService', () => {
         theme,
         loggedDate: DateUtil.date(2025, 4, 1, 4),
       };
-      console.info(themeLogEntity.loggedDate);
+
       mockThemeLogRepository.getLastLog.mockResolvedValue(themeLogEntity);
       const mockFindById = mockThemeRepository.findById.mockResolvedValue(themeEntity);
       const mockGetRandomTheme = mockThemeRepository.getRandomTheme.mockResolvedValue(theme);

--- a/src/modules/theme/theme.service.ts
+++ b/src/modules/theme/theme.service.ts
@@ -58,7 +58,7 @@ export class ThemeService implements OnModuleInit {
       return;
     } else if (!this.todayTheme) {
       this.logger.debug('메모리에 존재하지 않아 마지막 로그로부터 새로운 주제를 할당합니다.');
-      const lastTheme = await this.themeRepository.findById(lastLog.themeId);
+      const lastTheme = await this.themeRepository.findById(lastLog.theme.id);
       if (lastTheme) {
         this.todayTheme = lastTheme;
         this.logger.debug(`오늘의 주제 : ${this.todayTheme.text}`);

--- a/src/modules/theme/theme.service.ts
+++ b/src/modules/theme/theme.service.ts
@@ -53,16 +53,16 @@ export class ThemeService implements OnModuleInit {
       return;
     }
 
-    if (!DateUtil.hasExpired(lastLog.loggedDate)) {
+    if (DateUtil.hasExpired(lastLog.loggedDate)) {
       await this.updateTodayTheme();
       return;
-    }
-
-    this.logger.debug('마지막 로그로부터 새로운 주제를 할당합니다.');
-    const lastTheme = await this.themeRepository.findById(lastLog.theme.id);
-    if (lastTheme) {
-      this.todayTheme = lastTheme;
-      this.logger.debug(`오늘의 주제 : ${this.todayTheme.text}`);
+    } else if (!this.todayTheme) {
+      this.logger.debug('메모리에 존재하지 않아 마지막 로그로부터 새로운 주제를 할당합니다.');
+      const lastTheme = await this.themeRepository.findById(lastLog.themeId);
+      if (lastTheme) {
+        this.todayTheme = lastTheme;
+        this.logger.debug(`오늘의 주제 : ${this.todayTheme.text}`);
+      }
     }
   }
 }

--- a/src/modules/theme/theme.service.ts
+++ b/src/modules/theme/theme.service.ts
@@ -1,12 +1,10 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 
-import { Environment, EnvironmentVariables } from '@common/env';
-import { hasTimePassed } from '@common/utils/date';
+import { QueryRunnerFactory } from '@database/query-runner.factory';
+import { DateUtil } from '@common/utils/date';
 import { ThemeRepository } from '@theme/theme.repository';
 import { ThemeLogRepository } from '@theme/theme-log.repository';
 import { ThemeEntity } from '@theme/entities';
-import { QueryRunnerFactory } from '@database/query-runner.factory';
 
 @Injectable()
 export class ThemeService implements OnModuleInit {
@@ -16,7 +14,6 @@ export class ThemeService implements OnModuleInit {
   constructor(
     private readonly themeRepository: ThemeRepository,
     private readonly themeLogRepository: ThemeLogRepository,
-    private readonly configService: ConfigService<EnvironmentVariables, true>,
     private readonly queryRunnerFactory: QueryRunnerFactory,
   ) {}
 
@@ -56,11 +53,7 @@ export class ThemeService implements OnModuleInit {
       return;
     }
 
-    const isAfter = () => this.configService.get<Environment>('NODE_ENV') === Environment.Development
-      ? hasTimePassed(lastLog.loggedDate, 'minute', 1)
-      : hasTimePassed(lastLog.loggedDate, 'day', 1);
-
-    if (isAfter()) {
+    if (!DateUtil.hasExpired(lastLog.loggedDate)) {
       await this.updateTodayTheme();
       return;
     }


### PR DESCRIPTION
## 변경 사항 요약 (Summary)

 - /me/diaries/:id를 통해 요청 가능합니다. 
 - 4AM 기준으로 24시간 동안 일기 수정이 유효합니다. 
 - DateUtil 클래스로 리팩토링 
 - DiaryEditExpiredException 추가
 - ThemeEntity에서 갑작스러운 알 수 없는 버그로 인해 릴레이션을 명시했습니다.

## 관련 이슈 (Related Issues)

- Closes #19 

## 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.